### PR TITLE
Add shebang-line

### DIFF
--- a/seedminer/seedminer_launcher3.py
+++ b/seedminer/seedminer_launcher3.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Seedminer v2.1.5
 from binascii import hexlify, unhexlify
 import glob

--- a/seedminer/seedminer_launcher3_GUI.py
+++ b/seedminer/seedminer_launcher3_GUI.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 #Seedminer Text-based UI v1.0
 
 #fef0fef0fef0fef0fef0fef0fef0fef0


### PR DESCRIPTION
Adding a shebang-line in order to remove the need to explicitly launch the python scripts with python if `/usr/bin/env` support is present.